### PR TITLE
Added a ref to the GeoNames dump

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -25,3 +25,5 @@ dem               : digital elevation model, srtm3 or gtopo30, average elevation
 timezone          : the timezone id (see file timeZone.txt) varchar(40)
 modification date : date of last modification in yyyy-MM-dd format
 ```
+
+Source: [GeoNames dump](http://download.geonames.org/export/dump/)


### PR DESCRIPTION
Some people could not find the admin1Codes.txt files to do the match between province codes and their names.
I added a link to the dump of GeoNames so they can find those files.